### PR TITLE
Add variable output

### DIFF
--- a/exercises/066-isEitherEvenOrAreBoth7/test.js
+++ b/exercises/066-isEitherEvenOrAreBoth7/test.js
@@ -7,6 +7,8 @@ test('Function "isEitherEvenOrAreBoth7" must exist', () => {
 
 test('Function must return parameter true or false if is even or is both are 7', () => {
     const isEitherEvenOrAreBoth7 = rewire('./app.js').__get__("isEitherEvenOrAreBoth7");
+    
+    let output =false;
 
     output = isEitherEvenOrAreBoth7(3, 7);
     expect(output).toBe(false)


### PR DESCRIPTION
Add variable output as it is missing in test.js causing the test to failed. Below is the console output.

Socket error: testing-error   ● Function must return parameter true or false if is even or is both are 7

    ReferenceError: output is not defined

       9 |     const isEitherEvenOrAreBoth7 = rewire('./app.js').__get__("isEitherEvenOrAreBoth7");
      10 |
    > 11 |     output = isEitherEvenOrAreBoth7(3, 7);
         |           ^
      12 |     expect(output).toBe(false)
      13 |     output = isEitherEvenOrAreBoth7(2, 3);
      14 |     expect(output).toBe(true)

      at Object.<anonymous> (exercises/066-isEitherEvenOrAreBoth7/test.js:11:11)